### PR TITLE
update the next_up calculator to 'snake'

### DIFF
--- a/blueprints/draft_blueprint.py
+++ b/blueprints/draft_blueprint.py
@@ -1,4 +1,5 @@
 """ The main blueprint file for now."""
+import math
 import random
 
 from flask import (
@@ -65,22 +66,26 @@ def generate_leaderboard(leaderboard_type):
 
 def next_up():
     """ returns team id of the next team up"""
-    last_pick = db.session.query(Selection).order_by(Selection.draftdraft_selection.desc()).first()
-    if last_pick is None:
-        next_pick = 0
+    last_pick_number = db.session.query(Selection).order_by(Selection.draftdraft_selection.desc()).first()
+    if last_pick_number is None:
+        prev_pick = 0
     else:
-        next_pick = last_pick.draftdraft_selection
+        prev_pick = last_pick_number.draftdraft_selection
 
+    next_pick_number = prev_pick + 1
     all_teams = db.session.query(User).all()
-    total_teams = len(all_teams)
-    next_pick = (next_pick % len(all_teams)) + 1
+    team_count = len(all_teams)
+    current_round = math.ceil(next_pick_number / team_count)
+    pick_within_round = (next_pick_number % team_count) or team_count
+    if current_round % 2 == 0:
+        pick_within_round = team_count - pick_within_round + 1
 
     # if no draft has been set yet then return empty for now.
     # the below code assumes if any team has a pick all teams have a piack
     if not all_teams or not all_teams[0].pick:
         return None
 
-    return next(team for team in all_teams if team.pick.pick_order == next_pick)
+    return next(team for team in all_teams if team.pick.pick_order == pick_within_round)
 
 
 @draft.route('/home')  # maybe theres a better way to do url_for('/')

--- a/templates/draft_page.html
+++ b/templates/draft_page.html
@@ -34,7 +34,7 @@
         <h1>Next Pick: {% if next_pick %}{{ next_pick.team_name }}{% else %}Draft order not set{% endif %}</h1>
         <table class="table table-bordered border-3">
             <tr>
-                <th>Pick</th>
+                <th>Order</th>
                 <th>Team</th>
             </tr>
             {% for pick in pick_order %}


### PR DESCRIPTION
Rather than always going from pick 1 to x every round, enforce a snake ordering. go from 1 to x then x to 1 then 1 to x etc

I'd like to update the order/pick column to the actual overall pick number and maybe have a round number showing somewhere, but that's lesser priority