### PR TITLE
fix container divs on the view draft page

### DIFF
--- a/static/styles/base.css
+++ b/static/styles/base.css
@@ -10,10 +10,16 @@
 }
 
 .container {
+    /*
+    This accidentally applied to things on the view draft page.
+    Bring this back once i've got it applied to only the right things, and actually works. 
+    Largely replaced by the .draftContainer styling in draft_page.css which is also currently commented out.
+
     border: .5px solid white;
     margin-bottom: 40px;
     max-height: 450px;
     overflow-y: scroll;
+    */
 }
 
 .fill {


### PR DESCRIPTION
styling wasnt meant to be applied, so just remove the styling which isnt being used anywhere intentionally at the moment

got added here, https://github.com/ajpodell/draftdraft/commit/2934a4eb785a566867e2c9971dcfd63b55ae4f0c, but wasnt applied to anything on the make pick page which was the only one i meant to change at the time